### PR TITLE
Accessibility improvements (keyboard navigation & aria attributes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Teleport the menu outside of the component DOM tree. You can pass a valid string
 
 **Note**: top and left properties are calculated using a ref on the `.vue-select` with a `container.getBoundingClientRect()`.
 
+**aria**: `{ labelledby?: string }` (default: `undefined`)
+
+Aria attributes to be passed to the select control to improve accessibility.
+
 **getOptionLabel**: `(option: Option) => string` (default: `option => option.label`)
 
 A function to get the label of an option. This is useful when you want to use a property different from `label` as the label of the option.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Teleport the menu outside of the component DOM tree. You can pass a valid string
 
 **Note**: top and left properties are calculated using a ref on the `.vue-select` with a `container.getBoundingClientRect()`.
 
-**aria**: `{ labelledby?: string }` (default: `undefined`)
+**aria**: `{ labelledby?: string; required?: boolean; }` (default: `undefined`)
 
 Aria attributes to be passed to the select control to improve accessibility.
 

--- a/src/MenuOption.vue
+++ b/src/MenuOption.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from "vue";
+import { ref, watch } from "vue";
 
 const props = defineProps<{
+  menu: HTMLDivElement | null;
+  index: number;
   isFocused: boolean;
   isSelected: boolean;
 }>();
@@ -15,15 +17,24 @@ const option = ref<HTMLButtonElement | null>(null);
 // Scroll the focused option into view when it's out of the menu's viewport.
 watch(
   () => props.isFocused,
-  async () => {
-    if (props.isFocused) {
-      // Use nextTick to wait for the next DOM render.
-      await nextTick(() => {
-        option.value?.parentElement?.scrollTo({
-          top: option.value?.offsetTop - option.value?.parentElement?.offsetHeight + option.value?.offsetHeight,
-          behavior: "instant",
-        });
-      });
+  () => {
+    if (props.isFocused && props.menu) {
+      // Get child element with index
+      const option = props.menu.children[props.index] as HTMLDivElement;
+
+      const optionTop = option.offsetTop;
+      const optionBottom = optionTop + option.clientHeight;
+      const menuScrollTop = props.menu.scrollTop;
+      const menuHeight = props.menu.clientHeight;
+
+      if (optionTop < menuScrollTop) {
+        // eslint-disable-next-line vue/no-mutating-props
+        props.menu.scrollTop = optionTop;
+      }
+      else if (optionBottom > menuScrollTop + menuHeight) {
+        // eslint-disable-next-line vue/no-mutating-props
+        props.menu.scrollTop = optionBottom - menuHeight;
+      }
     }
   },
 );

--- a/src/MenuOption.vue
+++ b/src/MenuOption.vue
@@ -30,14 +30,14 @@ watch(
 </script>
 
 <template>
-  <button
+  <div
     ref="option"
-    type="button"
-    class="menu-option"
     tabindex="-1"
+    role="option"
     :class="{ focused: isFocused, selected: isSelected }"
+    :aria-disabled="false"
     @click="emit('select')"
   >
     <slot />
-  </button>
+  </div>
 </template>

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -219,6 +219,18 @@ const handleNavigation = (e: KeyboardEvent) => {
       menuOpen.value = false;
       search.value = "";
     }
+
+    // When pressing backspace with no search, remove the last selected option.
+    if (e.key === "Backspace" && search.value.length === 0 && selected.value.length > 0) {
+      e.preventDefault();
+
+      if (props.isMulti) {
+        selected.value = (selected.value as string[]).slice(0, -1);
+      }
+      else {
+        selected.value = "";
+      }
+    }
   }
 };
 

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -138,6 +138,11 @@ const openMenu = (options?: { focusInput?: boolean }) => {
   }
 };
 
+const closeMenu = () => {
+  menuOpen.value = false;
+  search.value = "";
+};
+
 const focusInput = () => {
   if (input.value) {
     input.value.focus();
@@ -295,6 +300,7 @@ onBeforeUnmount(() => {
           :disabled="isDisabled"
           :placeholder="selectedOptions.length === 0 ? placeholder : ''"
           @focus="openMenu({ focusInput: false })"
+          @keydown.tab="closeMenu"
         >
       </div>
 

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -128,7 +128,7 @@ const filteredOptions = computed(() => {
 
 const selectedOptions = computed(() => {
   if (props.isMulti) {
-    return props.options.filter((option) => (selected.value as string[]).includes(option.value));
+    return (selected.value as string[]).map((value) => props.options.find((option) => option.value === value)!);
   }
 
   const found = props.options.find((option) => option.value === selected.value);

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -98,8 +98,9 @@ const selected = defineModel<string | string[]>({
   },
 });
 
-const container = ref<HTMLElement | null>(null);
+const container = ref<HTMLDivElement | null>(null);
 const input = ref<HTMLInputElement | null>(null);
+const menu = ref<HTMLDivElement | null>(null);
 
 const search = ref("");
 const menuOpen = ref(false);
@@ -384,6 +385,7 @@ onBeforeUnmount(() => {
     <Teleport :to="teleport" :disabled="!teleport">
       <div
         v-if="menuOpen"
+        ref="menu"
         class="menu"
         role="listbox"
         :aria-label="aria?.labelledby"
@@ -400,6 +402,8 @@ onBeforeUnmount(() => {
           type="button"
           class="menu-option"
           :class="{ focused: focusedOption === i, selected: option.value === selected }"
+          :menu="menu"
+          :index="i"
           :is-focused="focusedOption === i"
           :is-selected="option.value === selected"
           @select="setOption(option.value)"

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -50,6 +50,7 @@ const props = withDefaults(
      */
     aria?: {
       labelledby?: string;
+      required?: boolean;
     };
     /**
      * A function to get the label of an option. By default, it assumes the option is an
@@ -308,6 +309,7 @@ onBeforeUnmount(() => {
         :aria-description="placeholder"
         :aria-labelledby="aria?.labelledby"
         :aria-label="selectedOptions.length ? selectedOptions.map(getOptionLabel).join(', ') : ''"
+        :aria-required="aria?.required"
       >
         <div
           v-if="!props.isMulti && selectedOptions[0]"

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -46,6 +46,12 @@ const props = withDefaults(
      */
     teleport?: string;
     /**
+     * ARIA attributes to describe the select component. This is useful for accessibility.
+     */
+    aria?: {
+      labelledby?: string;
+    };
+    /**
      * A function to get the label of an option. By default, it assumes the option is an
      * object with a `label` property. Used to display the selected option in the input &
      * inside the options menu.
@@ -70,6 +76,7 @@ const props = withDefaults(
     isMulti: false,
     closeOnSelect: true,
     teleport: undefined,
+    aria: undefined,
     getOptionLabel: (option: Option) => option.label,
     getMultiValueLabel: (option: Option) => option.label,
   },
@@ -261,7 +268,10 @@ onBeforeUnmount(() => {
         :class="{ multi: isMulti }"
         role="combobox"
         :aria-expanded="menuOpen"
-        :aria-label="placeholder"
+        :aria-describedby="placeholder"
+        :aria-description="placeholder"
+        :aria-labelledby="aria?.labelledby"
+        :aria-label="selectedOptions.length ? selectedOptions.map(getOptionLabel).join(', ') : ''"
       >
         <div
           v-if="!props.isMulti && selectedOptions[0]"
@@ -336,6 +346,9 @@ onBeforeUnmount(() => {
       <div
         v-if="menuOpen"
         class="menu"
+        role="listbox"
+        :aria-label="aria?.labelledby"
+        :aria-multiselectable="isMulti"
         :style="{
           width: props.teleport ? `${container?.getBoundingClientRect().width}px` : '100%',
           top: props.teleport ? calculateMenuPosition().top : 'unset',

--- a/website/Website.vue
+++ b/website/Website.vue
@@ -17,7 +17,7 @@ import CustomOption from "./CustomOption.vue";
     <a
       href="https://github.com/TotomInc/vue3-select-component"
       target="_blank"
-      class="mt-4 border border-neutral-200 bg-white rounded text-sm font-medium px-4 py-2 text-neutral-950 flex items-center self-start mx-auto hover:bg-neutral-50 focus:outline-none gap-1.5"
+      class="mt-4 border border-neutral-200 bg-white rounded text-sm font-medium px-4 py-2 text-neutral-950 flex items-center self-start mx-auto hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-1 gap-1.5"
     >
       View docs on GitHub
       <svg


### PR DESCRIPTION
See #1, there are accessibility issues on the component.

- Using `tab` to navigate out of the select will close the menu.
- Improved `aria-` attributes on various DOM nodes.
- Improved keyboard navigation.

Once merged, this should closes #1.