### PR TITLE
feat(select): add disabled option property

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,12 +42,13 @@ export default defineConfig({
         ],
       },
       {
-        text: "Demo",
+        text: "Demo links",
         items: [
           { text: "Single Select", link: "/demo/single-select" },
           { text: "Multiple Select", link: "/demo/multiple-select" },
           { text: "Custom Option Slot", link: "/demo/custom-option-slot" },
           { text: "Pre-Selected Values (single & multi)", link: "/demo/pre-selected-values" },
+          { text: "Disabled Options", link: "/demo/disabled-options" },
           { text: "With Menu Header", link: "/demo/with-menu-header" },
           { text: "With Complex Menu Filter", link: "/demo/with-complex-menu-filter.md" },
         ],
@@ -60,5 +61,7 @@ export default defineConfig({
     ],
 
     search: { provider: "local" },
+
+    outline: "deep",
   },
 });

--- a/docs/demo/disabled-options.md
+++ b/docs/demo/disabled-options.md
@@ -1,0 +1,52 @@
+---
+title: 'Disabled Options'
+---
+
+# Disabled Options
+
+The following example demonstrates how to use the `VueSelect` component with disabled options.
+
+<script setup>
+import { ref } from "vue";
+
+import VueSelect from "../../src";
+
+const selected = ref("");
+</script>
+
+<VueSelect
+  v-model="selected"
+  :options="[
+    { label: 'Option #1', value: 'option_1' },
+    { label: 'Option #2', value: 'option_2', disabled: true },
+    { label: 'Option #3', value: 'option_3' },
+    { label: 'Option #4', value: 'option_4' },
+    { label: 'Option #5', value: 'option_5', disabled: true },
+    { label: 'Option #6', value: 'option_6' },
+  ]"
+/>
+
+## Demo source-code
+
+```vue
+<script setup lang="ts">
+import { ref } from "vue";
+import VueSelect from "vue3-select-component";
+
+const selected = ref("");
+</script>
+
+<template>
+  <VueSelect
+    v-model="selected"
+    :options="[
+      { label: 'Option #1', value: 'option_1' },
+      { label: 'Option #2', value: 'option_2', disabled: true },
+      { label: 'Option #3', value: 'option_3' },
+      { label: 'Option #4', value: 'option_4' },
+      { label: 'Option #5', value: 'option_5', disabled: true },
+      { label: 'Option #6', value: 'option_6' },
+    ]"
+  />
+</template>
+```

--- a/docs/dropdown-options.md
+++ b/docs/dropdown-options.md
@@ -18,6 +18,18 @@ When using the `options` prop, you can pass an array of objects to the component
 If you are using TypeScript, make sure to read the [TypeScript usage](/typescript) section to leverage proper type-safety.
 :::
 
+## Disabled option(s)
+
+You can disable an option by adding a `disabled` property to the object. The `disabled` property should be a boolean.
+
+When an option is disabled, it cannot be selected nor focused/navigated to using the keyboard.
+
+```vue
+<template>
+  <VueSelect :options="[{ label: 'Option #1', value: 'option_1', disabled: true }]" />
+</template>
+```
+
 ## Passing extra properties
 
 You can pass extra properties to the options object. The component will ignore them but you will be able to manipulate those extra properties using some props and slots.

--- a/docs/props.md
+++ b/docs/props.md
@@ -34,6 +34,7 @@ A list of all possible options to choose from. Each option should have a `label`
 type Option<T> = {
   label: string;
   value: T;
+  disabled?: boolean;
 };
 ```
 
@@ -44,6 +45,16 @@ This type is exported from the component and can be imported in your application
 ::: info
 If you are using TypeScript, you can leverage proper type-safety between `option.value` & `v-model`. Read more about [TypeScript usage](/typescript).
 :::
+
+### option.disabled
+
+**Type**: `boolean`
+
+**Required**: `false`
+
+**Default**: `undefined`
+
+Whether the option should be disabled. When an option is disabled, it cannot be selected nor focused/navigated to using the keyboard. It also benefits from extra aria attributes to improve accessibility.
 
 ## displayedOptions
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -24,7 +24,7 @@ List of available CSS variables (pulled from the demo):
   --vs-input-outline: #3b82f6;
   --vs-input-placeholder-color: #52525b;
 
-  --vs-padding: .25rem .5rem;
+  --vs-padding: 0.25rem 0.5rem;
   --vs-border: 1px solid #e4e4e7;
   --vs-border-radius: 4px;
   --vs-font-size: 16px;
@@ -35,7 +35,7 @@ List of available CSS variables (pulled from the demo):
 
   --vs-menu-offset-top: 8px;
   --vs-menu-height: 200px;
-  --vs-menu-padding: 8px 0;
+  --vs-menu-padding: 0;
   --vs-menu-border: 1px solid #e4e4e7;
   --vs-menu-bg: #fff;
   --vs-menu-box-shadow: none;
@@ -49,6 +49,8 @@ List of available CSS variables (pulled from the demo):
   --vs-option-hover-color: #dbeafe;
   --vs-option-focused-color: var(--vs-option-hover-color);
   --vs-option-selected-color: #93c5fd;
+  --vs-option-disabled-color: #f4f4f5;
+  --vs-option-disabled-text-color: #52525b;
 
   --vs-multi-value-gap: 4px;
   --vs-multi-value-padding: 4px;
@@ -64,7 +66,7 @@ List of available CSS variables (pulled from the demo):
   --vs-icon-size: 20px;
   --vs-icon-color: var(--vs-text-color);
 
-  --vs-dropdown-transition: transform .25s ease-out;
+  --vs-dropdown-transition: transform 0.25s ease-out;
 }
 ```
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -14,10 +14,11 @@ Generics allow you to define a type that can be used in multiple places with dif
 
 A common type you'll see is the `Option` type, which is used to define the options of the select component.
 
-```typescript
+```ts
 type Option<T> = {
   label: string;
   value: T;
+  disabled?: boolean;
 };
 ```
 

--- a/playground/Playground.vue
+++ b/playground/Playground.vue
@@ -22,6 +22,9 @@ const userOptions: UserOption[] = [
   { label: "Bob", value: 2, username: "bob" },
   { label: "Charlie", value: 3, username: "charlie" },
   { label: "David", value: 4, username: "david" },
+  { label: "John", value: 5, username: "john" },
+  { label: "Admin", value: 6, username: "admin" },
+  { label: "Root", value: 6, username: "root" },
 ];
 </script>
 

--- a/src/MenuOption.vue
+++ b/src/MenuOption.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
   index: number;
   isFocused: boolean;
   isSelected: boolean;
+  isDisabled: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -45,8 +46,9 @@ watch(
     ref="option"
     tabindex="-1"
     role="option"
-    :class="{ focused: isFocused, selected: isSelected }"
-    :aria-disabled="false"
+    :class="{ focused: isFocused, selected: isSelected, disabled: isDisabled }"
+    :aria-disabled="isDisabled"
+    :aria-selected="isSelected"
     @click="emit('select')"
     @keydown.enter="emit('select')"
   >

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export type Option<T> = {
   label: string;
   value: T;
+  disabled?: boolean;
 };


### PR DESCRIPTION
- Add `option.disabled` property:
  - When an option is disabled, it cannot focused nor selected
  - A disabled option has 2 new CSS variables to set a background-color and text-color
- Refactored unit-tests, added helpers functions
- Updated docs with a new demo page for the `option.disabled` property
- Added nested outline configuration on the docs
- Improved a11y with dynamic `aria-selected` attribute on options

Closes #81 