### PR TITLE
fix: improve selectedOptions computation for multi-select with isMulti

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -146,11 +146,14 @@ const availableOptions = computed(() => {
 });
 
 const selectedOptions = computed(() => {
-  if (props.isMulti) {
-    // We can safely assume it's an array due to the `isMulti` prop validation done earlier.
+  if (props.isMulti && Array.isArray(selected.value)) {
     return (selected.value as OptionValue[]).map(
       (value) => props.options.find((option) => option.value === value)!,
     );
+  }
+
+  if (props.isMulti && !Array.isArray(selected.value)) {
+    console.warn(`[vue3-select-component warn]: The v-model provided should be an array when using \`isMulti\` prop, instead it was: ${selected.value}`);
   }
 
   const found = props.options.find((option) => option.value === selected.value);


### PR DESCRIPTION
Fix an issue when using `isMulti` and receiving something different than an array as a `v-model`. Make sure the computed selectedOptions still return an empty array in this case, instead of throwing an error.

I believe this is a mistake that should be handled on the code of the user-side, but for convenience we can add a missing check and if it doesn't pass, return an empty array which doesn't break anything.

Also, a warning message has been added to ensure the developer is aware of the code issue.

Closes #92.