### PR TITLE
fix: add tag slot for multi-select

### DIFF
--- a/docs/slots.md
+++ b/docs/slots.md
@@ -42,6 +42,23 @@ Customize the rendered HTML if a selected option (inside the select control). Yo
 </template>
 ```
 
+## tag
+
+**Type**: `slotProps: { option: Option, removeOption: () => void }`
+
+Customize the rendered HTML for a tag representing a selected option in multi-select mode (when `isMulti` is true). You can use the slot props to retrieve the current selected option and a function to remove the option from the selection.
+
+```vue
+<template>
+  <VueSelect v-model="option" :options="options">
+    <template #tag="{ option }">
+      My value is: {{ option.value }}
+      <span @click="removeOption">X</span>
+    </template>
+  </VueSelect>
+</template>
+```
+
 ## menu-header
 
 **Type**: `slotProps: {}`

--- a/playground/Playground.vue
+++ b/playground/Playground.vue
@@ -50,7 +50,14 @@ const userOptions: UserOption[] = [
         :is-multi="true"
         :is-loading="isLoading"
         placeholder="Pick users"
-      />
+      >
+        <template #tag="{ option }">
+          <span class="custom-tags">
+            {{ option.label }}
+            <span class="custom-x-mark" @click="removeOption">&times;</span>
+          </span>
+        </template>
+      </VueSelect>
 
       <p class="selected-value">
         Selected user value: {{ activeUsers || "none" }}
@@ -88,6 +95,21 @@ body {
       font-size: 14px;
       font-weight: 500;
       font-family: "IBM Plex Mono", monospace;
+    }
+
+    .custom-tags {
+      background-color: #e0f7fa;
+      padding: 5px 10px;
+      margin: 3px;
+      border-radius: 12px;
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .custom-x-mark {
+      cursor: pointer;
+      margin-left: 8px;
+      color: #00796b;
     }
   }
 }

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -402,17 +402,25 @@ onBeforeUnmount(() => {
           </slot>
         </div>
 
-        <template v-if="props.isMulti && selectedOptions.length">
-          <button
+        <div
+          v-if="props.isMulti && selectedOptions.length"
+          class="multi-value-container"
+        >
+          <div
             v-for="(option, i) in selectedOptions"
             :key="i"
-            type="button"
-            class="multi-value"
             @click="removeOption(option)"
           >
-            {{ getMultiValueLabel(option) }}<XMarkIcon />
-          </button>
-        </template>
+            <slot
+              name="tag"
+              :option="option"
+              :remove-option="() => removeOption(option)"
+            >
+              <span class="multi-value">
+                {{ getMultiValueLabel(option) }}<XMarkIcon /></span>
+            </slot>
+          </div>
+        </div>
 
         <input
           :id="inputId"
@@ -634,6 +642,12 @@ onBeforeUnmount(() => {
   line-height: var(--vs-line-height);
   color: var(--vs-text-color);
   z-index: 0;
+}
+
+.multi-value-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--vs-multi-value-gap);
 }
 
 .multi-value {


### PR DESCRIPTION
Closes #128.

This PR adds a `#tag` slot with access to both `option` and `removeOption()` values, and documents this tag option in Vitepress.

I've also adapted the Playground code to implement this slot as a demo; I thought that might be helpful. But this may not be desired, I'm happy to revert that change if so.

I hope I did this right - it was my first time setting up a Vue slot template! Let me know if any adjustments are needed.

![image](https://github.com/user-attachments/assets/c02f180f-4212-4ac7-877c-f64322d31365)
