### PR TITLE
Fix for issue with `v-model` updates in multi-select mode (`is-multi=true`)

### DIFF
--- a/src/Select.spec.ts
+++ b/src/Select.spec.ts
@@ -223,7 +223,7 @@ describe("multi-select options", () => {
     await openMenu(wrapper);
     await wrapper.get("div[role='option']").trigger("click");
 
-    expect(wrapper.props("modelValue")).toStrictEqual([options[0].value]);
+    expect(wrapper.emitted("update:modelValue")).toStrictEqual([[[options[0].value]]]);
     expect(wrapper.get(".multi-value").element.textContent).toBe(options[0].label);
   });
 
@@ -282,7 +282,7 @@ describe("clear button", () => {
     await wrapper.get("div[role='option']").trigger("click");
     await wrapper.get(".clear-button").trigger("click");
 
-    expect(wrapper.props("modelValue")).toStrictEqual([options[0].value]);
+    expect(wrapper.emitted("update:modelValue")).toStrictEqual([[[options[0].value]], [ [ ] ]]);
     expect(wrapper.find(".clear-button").exists()).toBe(false);
   });
 });

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -154,7 +154,7 @@ const setOption = (option: GenericOption) => {
       const isAlreadyPresent = selected.value.find((v) => v === option.value);
 
       if (!isAlreadyPresent) {
-        selected.value.push(option.value);
+        selected.value = [...selected.value, option.value]
       }
       else {
         selected.value = selected.value.filter((v) => v !== option.value);


### PR DESCRIPTION
Hello!

While using the component with the `is-multi` option set to `true`, I encountered the problem that, when selecting a new item from the dropdown, the bound `v-model` array does not trigger an update.  

As a result, watchers or computed properties depending on the selected values are not notified of changes.

Here’s a minimal example demonstrating the issue:

```vue
<script setup>
import { ref, watch } from 'vue'
import VueSelect from 'vue3-select-component'

const selected = ref([])

watch(selected, (newValues, oldValues) => {
    console.log(`Selected values changed from '${oldValues}' to '${newValues}'`)
})
</script>

<template>
  <VueSelect
    v-model="selected"
    :is-multi="true"
    :options="[
      { label: 'Option #1', value: 'option_1' },
      { label: 'Option #2', value: 'option_2' },
      { label: 'Option #3', value: 'option_3' },
    ]"
    placeholder="Select an option"
  />
</template>
```

Currently, the `console.log` inside the watcher never runs after adding a new option (only after removing it), because the selected array is not properly updated.

I just created a small fix that ensures the v-model binding behaves as expected in multi-select mode.

Please let me know if there’s anything else I should adjust in the PR!

Thanks!
Diego.
