### PR TITLE
Fix multi-select option removal logic

### DIFF
--- a/src/Select.vue
+++ b/src/Select.vue
@@ -189,7 +189,7 @@ const setOption = (option: GenericOption) => {
 const removeOption = (option: GenericOption) => {
   if (props.isMulti && !props.isDisabled) {
     if (Array.isArray(selected.value)) {
-      selected.value = selected.value.filter((value) => value !== option.value);
+      selected.value = selected.value.filter((value) => value !== props.getOptionValue(option));
       emit("optionDeselected", option);
     }
     else if (!props.disableInvalidVModelWarn) {


### PR DESCRIPTION
Updated the removeOption method to use props.getOptionValue for comparison, ensuring correct deselection behavior when option values are complex objects.

Should fix #310 