### PR TITLE
Fix selecting items with selectOnBlur=false

### DIFF
--- a/playground/PlaygroundLayout.vue
+++ b/playground/PlaygroundLayout.vue
@@ -14,6 +14,7 @@ const links = [
   { value: "/custom-option-label-value", label: "Custom Option Label/Value" },
   { value: "/custom-search-filter", label: "Custom Search Filter" },
   { value: "/select-is-loading", label: "Select isLoading" },
+  { value: "/no-select-on-blur", label: "No Select on Blur" },
   { value: "/taggable-no-options-slot", label: "Taggable No Options Slot" },
   { value: "/controlled-menu", label: "Controlled Menu" },
   { value: "/menu-header", label: "Menu Header" },

--- a/playground/demos/NoSelectOnBlur.vue
+++ b/playground/demos/NoSelectOnBlur.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { Option } from "../../src";
+import { ref } from "vue";
+import VueSelect from "../../src";
+
+const selected = ref<string | null>(null);
+
+const options = ref<Option<string>[]>([
+  { label: "Alice's Adventures in Wonderland", value: "alice" },
+  { label: "A Wizard of Earthsea", value: "wizard" },
+  { label: "Harry Potter and the Philosopher's Stone", value: "harry_potter_1" },
+  { label: "Harry Potter and the Chamber of Secrets", value: "harry_potter_2" },
+]);
+
+const handleCreateOption = (value: string) => {
+  options.value.push({ label: value, value });
+  selected.value = value;
+};
+</script>
+
+<template>
+  <VueSelect
+    v-model="selected"
+    :options="options"
+    :is-multi="false"
+    :is-taggable="true"
+    :select-on-blur="false"
+    placeholder="Pick a book"
+    @option-created="(value) => handleCreateOption(value)"
+  >
+    <template #taggable-no-options="{ option }">
+      <div class="custom-taggable-no-options">
+        Create option: {{ option }}
+      </div>
+    </template>
+  </VueSelect>
+
+  <p class="selected-value">
+    Selected book value: {{ selected || "none" }}
+  </p>
+</template>

--- a/playground/main.ts
+++ b/playground/main.ts
@@ -12,6 +12,7 @@ import MenuHeader from "./demos/MenuHeader.vue";
 import MenuPositioning from "./demos/MenuPositioning.vue";
 import MultiSelect from "./demos/MultiSelect.vue";
 import MultiSelectTaggable from "./demos/MultiSelectTaggable.vue";
+import NoSelectOnBlur from "./demos/NoSelectOnBlur.vue";
 import SelectIsLoading from "./demos/SelectIsLoading.vue";
 import SingleSelect from "./demos/SingleSelect.vue";
 import TaggableNoOptionsSlot from "./demos/TaggableNoOptionsSlot.vue";
@@ -31,6 +32,7 @@ const router = createRouter({
     { path: "/custom-option-label-value", component: CustomOptionLabelValue },
     { path: "/custom-search-filter", component: CustomSearchFilter },
     { path: "/select-is-loading", component: SelectIsLoading },
+    { path: "/no-select-on-blur", component: NoSelectOnBlur },
     { path: "/taggable-no-options-slot", component: TaggableNoOptionsSlot },
     { path: "/controlled-menu", component: ControlledMenu },
     { path: "/menu-header", component: MenuHeader },

--- a/src/Select.spec.ts
+++ b/src/Select.spec.ts
@@ -479,6 +479,17 @@ describe("component props", () => {
 
     expect(wrapper.findAll(".focused[role='option']")).toHaveLength(0);
   });
+
+  it("should select option on click if selectOnBlur is disabled", async () => {
+    const wrapper = mount(VueSelect, { props: { modelValue: null, options, selectOnBlur: false } });
+
+    await openMenu(wrapper);
+    await wrapper.get("input").trigger("blur");
+
+    await wrapper.get("div[role='option']").trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toStrictEqual([[options[0]?.value]]);
+    expect(wrapper.get(".single-value").text()).toBe(options[0]?.label);
+  });
 });
 
 describe("inputAttrs prop", () => {

--- a/src/Select.vue
+++ b/src/Select.vue
@@ -301,8 +301,6 @@ const handleInputBlur = () => {
       setOption(focusedOptionData);
     }
   }
-
-  closeMenu();
 };
 
 provide(PROPS_KEY, props);


### PR DESCRIPTION
Fixes #405 

Calling `closeMenu()` in the blur handler for the search input causes the menu to disappear before a user can select an item. Just removing this call fixes this issue. The menu will still close when the user moves the focus away from the component.

This also fixes another issue: when the menu is open, clicking the indicator did close and immediately re-open the menu.