### PR TITLE
Change taggable-no-options to accept props

### DIFF
--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -16,7 +16,7 @@ export type Slots<GenericOption extends Option<OptionValue>, OptionValue> = {
   "menu-header"?: () => any;
   "option"?: (props: { option: GenericOption; index: number; isFocused: boolean; isSelected: boolean; isDisabled: boolean }) => any;
   "no-options"?: () => any;
-  "taggable-no-options"?: () => any;
+  "taggable-no-options"?: (props: { option: string }) => any;
 };
 
 export type IndicatorsSlots<GenericOption extends Option<OptionValue>, OptionValue> = Pick<


### PR DESCRIPTION
```html
 <template #taggable-no-options="{ option }">
      Press enter to add {{ option }} option
    </template>
```

```
error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
error TS2339: Property 'option' does not exist on type 'undefined'.
```